### PR TITLE
#1 Fixes Japanese characters on Chromebook

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,12 @@
       font-weight: 700;
       line-height: 1;
     }
+
+    .github {
+      display: block;
+      text-align: center;
+      margin: 1em;
+    }
   </style>
 </head>
 <body class="system-font-i18n-sans">
@@ -56,6 +62,7 @@
     <li><a href="#about">About</a></li>
     <li><a href="#usage">Usage</a></li>
     <li><a href="#support">Support</a></li>
+    <li><a href="#changelog">Changelog</a></li>
     <li><a href="#type__variations">Variations</a></li>
     <li><a href="#type__sample">Sample</a></li>
     <li><a href="#type__vertical">Vertical</a></li>
@@ -153,12 +160,16 @@ body {
   systems will select "Helvetica Neue". Mavericks back to Kodiak will select
   "Lucida Grande".
 </p>
-<p>Windows and Windows Phone will select "Segoe UI". XP selects "Arial", not
-  Tahoma (does not have an italic variation).
+<p>
+  Chromebook will select "Noto Sans" and correctly use "Noto Sans CJK JP"
+  for Japanese characters.
 </p>
 <p>Android will select "Roboto".</p>
 <p>Ubuntu will use the apty named Ubuntu, and other linux variants will select
   "Oxygen-Sans" or "Cantarell"
+</p>
+<p>Windows and Windows Phone will select "Segoe UI". XP selects "Arial", not
+  Tahoma (does not have an italic variation).
 </p>
 <p>This project has optimized unicode typesetting for English <sup>(unicode ranges
   basic-latin, latin-1 supplement, general punctuation, superscripts &amp;
@@ -166,6 +177,18 @@ body {
   <sup>(CJK symbols and punctuation, Hiragana, Katakana, CJK unified ideographs)</sup>.
   The project is accepting help in supporting other languages.
 </p>
+<p>[<a href="#top">Top</a>]</p>
+
+<h2 id="changelog">Changelog</h2>
+<ol>
+  <li>0.1.0:
+    Initial release
+  </li>
+  <li>0.1.1:
+    Fixes Japanese characters on Chromebook rendering in "Noto Sans CJK SC"
+    (Simplified Chinese) to instead use "Noto Sans CJK JP".
+  </li>
+</ol>
 <p>[<a href="#top">Top</a>]</p>
 
 <hr>
@@ -556,6 +579,18 @@ body {
       <footer><p>[<a href="#top">Top</a>]</p></footer>
     </article>
   </section>
+
+  <footer>
+    <a class="github" href="https://github.com/mirai-audio/system-font-i18n-css">
+      <svg height="32" version="1.1" viewBox="0 0 16 16" width="32">
+        <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z">
+        </path>
+      </svg>
+    </a>
+    <a href="https://github.com/mirai-audio/system-font-i18n-css">
+      <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png">
+    </a>
+  </footer>
 </main>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "system-font-i18n-css",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A modern font stack for consistent multi-lingual typesetting",
   "bugs": "https://github.com/mirai-audio/system-font-i18n-css/issues",
   "homepage": "https://mirai-audio.github.io/system-font-i18n-css",

--- a/system-font-i18n.css
+++ b/system-font-i18n.css
@@ -33,7 +33,7 @@ unicode range: english (latin-1) and more
     local(".SFNSText-Light"), /* macOS Firefox El Capitan+ */
     local(".HelveticaNeueDeskInterface-Light"), /* macOS Yosemite */
     local(".LucidaGrandeUI"), /* macOS Kodiak-Mavericks */
-    local("Noto"), local("Roboto"), /* Linux, Android */
+    local("Noto Sans"), local("Roboto"), /* Linux, Chromebook, Android */
     local("Oxygen-Sans"), local("Ubuntu"), local("Cantarell"), /* KDE, Ubuntu, Gnome */
     local("Segoe UI"), local("Arial"); /* Window Phone, Windows Vista+ */
 
@@ -65,7 +65,7 @@ unicode range: english (latin-1) and a bit more
     local(".SFNSText-LightItalic"), /* macOS Firefox El Capitan+ */
     local(".HelveticaNeueDeskInterface-Light"), /* macOS Yosemite */
     local(".LucidaGrandeUI"), /* macOS Kodiak-Mavericks */
-    local("Noto"), local("Roboto"), /* Linux, Android */
+    local("Noto Sans"), local("Roboto"), /* Linux, Chromebook, Android */
     local("Oxygen-Sans"), local("Ubuntu"), local("Cantarell"), /* KDE, Ubuntu, Gnome */
     local("Segoe UI"), local("Arial"); /* Window Phone, Windows Vista+ */
   unicode-range:
@@ -95,7 +95,7 @@ unicode range: english (latin-1) and a bit more
     local(".SFNSText"), /* macOS Firefox El Capitan+ */
     local(".HelveticaNeueDeskInterface-Regular"), /* macOS Yosemite */
     local(".LucidaGrandeUI"), /* macOS Kodiak-Mavericks */
-    local("Noto"), local("Roboto"), /* Linux, Android */
+    local("Noto Sans"), local("Roboto"), /* Linux, Chromebook, Android */
     local("Oxygen-Sans"), local("Ubuntu"), local("Cantarell"), /* KDE, Ubuntu, Gnome */
     local("Segoe UI"), local("Arial"); /* Window Phone, Windows Vista+ */
   unicode-range:
@@ -124,7 +124,7 @@ unicode range: english (latin-1) and a bit more
     local(".SFNSText"), /* macOS Firefox El Capitan+ */
     local(".HelveticaNeueDeskInterface-Regular"), /* macOS Yosemite */
     local(".LucidaGrandeUI"), /* macOS Kodiak-Mavericks */
-    local("Noto"), local("Roboto"), /* Linux, Android */
+    local("Noto Sans"), local("Roboto"), /* Linux, Chromebook, Android */
     local("Oxygen-Sans"), local("Ubuntu"), local("Cantarell"), /* KDE, Ubuntu, Gnome */
     local("Segoe UI"), local("Arial"); /* Window Phone, Windows Vista+ */
   unicode-range:
@@ -154,7 +154,7 @@ unicode range: english (latin-1) and a bit more
     local(".SFNSText-Bold"), /* macOS Firefox El Capitan+ */
     local(".HelveticaNeueDeskInterface-Bold"), /* macOS Yosemite */
     local(".LucidaGrandeUI"), /* macOS Kodiak-Mavericks */
-    local("Noto"), local("Roboto"), /* Linux, Android */
+    local("Noto Sans"), local("Roboto"), /* Linux, Chromebook, Android */
     local("Oxygen-Sans"), local("Ubuntu"), local("Cantarell"), /* KDE, Ubuntu, Gnome */
     local("Segoe UI"), local("Arial"); /* Window Phone, Windows Vista+ */
   unicode-range:
@@ -184,7 +184,7 @@ unicode range: english (latin-1) and a bit more
     local(".SFNSText-BoldItalic"), /* macOS Firefox El Capitan+ */
     local(".HelveticaNeueDeskInterface-BoldItalic"), /* macOS Yosemite */
     local(".LucidaGrandeUI"), /* macOS Kodiak-Mavericks */
-    local("Noto"), local("Roboto"), /* Linux, Android */
+    local("Noto Sans"), local("Roboto"), /* Linux, Chromebook, Android */
     local("Oxygen-Sans"), local("Ubuntu"), local("Cantarell"), /* KDE, Ubuntu, Gnome */
     local("Segoe UI"), local("Arial"); /* Window Phone, Windows Vista+ */
   unicode-range:
@@ -216,7 +216,7 @@ unicode range: CJK Symbols and Punctuation, Hiragana, Katakana, CJK Unified
   font-weight: 300;
   src:
     local("HiraginoSans-W3"), local("Hiragino Sans W3"), /* macOS, iOS */
-    local("Noto Serif"), /* Android */
+    local("Noto Sans CJK JP"), /* Chromebook, Android */
     local("Meiryo"); /* Windows */
   unicode-range:
     U+3000-303F, /* CJK Symbols and Punctuation */
@@ -240,7 +240,7 @@ unicode range: CJK Symbols and Punctuation, Hiragana, Katakana, CJK Unified
   font-weight: 300;
   src:
     local("HiraginoSans-W3"), local("Hiragino Sans W3"), /* macOS, iOS */
-    local("Noto Serif"), /* Android */
+    local("Noto Sans CJK JP"), /* Chromebook, Android */
     local("Meiryo"); /* Windows */
   unicode-range:
     U+3000-303F, /* CJK Symbols and Punctuation */
@@ -264,7 +264,7 @@ unicode range: CJK Symbols and Punctuation, Hiragana, Katakana, CJK Unified
   font-weight: 400;
   src:
     local("HiraginoSans-W4"), local("Hiragino Sans W4"), /* macOS, iOS */
-    local("Noto Serif"), /* Android */
+    local("Noto Sans CJK JP"), /* Chromebook, Android */
     local("Meiryo"); /* Windows */
   unicode-range:
     U+3000-303F, /* CJK Symbols and Punctuation */
@@ -288,7 +288,7 @@ unicode range: CJK Symbols and Punctuation, Hiragana, Katakana, CJK Unified
   font-weight: 400;
   src:
     local("HiraginoSans-W4"), local("Hiragino Sans W4"), /* macOS, iOS */
-    local("Noto Serif"), /* Android */
+    local("Noto Sans CJK JP"), /* Chromebook, Android */
     local("Meiryo"); /* Windows */
   unicode-range:
     U+3000-303F, /* CJK Symbols and Punctuation */
@@ -312,7 +312,7 @@ unicode range: CJK Symbols and Punctuation, Hiragana, Katakana, CJK Unified
   font-weight: 700;
   src:
     local("HiraginoSans-W7"), local("Hiragino Sans W7"), /* macOS, iOS */
-    local("Noto Serif"), /* Android */
+    local("Noto Sans CJK JP"), /* Chromebook, Android */
     local("Meiryo"); /* Windows */
   unicode-range:
     U+3000-303F, /* CJK Symbols and Punctuation */
@@ -336,7 +336,7 @@ unicode range: CJK Symbols and Punctuation, Hiragana, Katakana, CJK Unified
   font-weight: 700;
   src:
     local("HiraginoSans-W7"), local("Hiragino Sans W7"), /* macOS, iOS */
-    local("Noto Serif"), /* Android */
+    local("Noto Sans CJK JP"), /* Chromebook, Android */
     local("Meiryo"); /* Windows */
   unicode-range:
     U+3000-303F, /* CJK Symbols and Punctuation */


### PR DESCRIPTION
Chromebook is rendering in "Noto Sans CJK SC" (Simplified Chinese) to instead use "Noto Sans CJK JP".

Fixes: mirai-audio/system-font-i18n-css#1

### Quality

* [x] Submitted a ticket for my issue if one did not already exist
  * [x] Ticket number is in the subject of the commit message
  * [x] Used [Github auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message
* [x] If you've changed APIs, update the documentation
* [x] Tested, all tests are passing
  * [x] Includes new tests for new functionality
* [x] Style - code passes all linting & validation checks 
  * [x] Code follows the contributing guidelines
  * [x] Code follows the style guide
* [x] Single commit - recently `git rebase -i` off of `master`
* [x] If you've removed any code, make sure there isn't dangling orphan code
